### PR TITLE
Add line comment parsing 

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,5 +1,6 @@
 {
   "comments": {
+    "lineComment": "//",
     "blockComment": ["/*", "*/"]
   },
   "brackets": [

--- a/syntaxes/mint.tmLanguage.json
+++ b/syntaxes/mint.tmLanguage.json
@@ -33,9 +33,21 @@
   ],
   "repository": {
     "comments": {
-      "name": "comment.block.mint",
-      "begin": "/\\*",
-      "end": "\\*/"
+      "patterns": [
+        {
+          "name": "comment.block.mint",
+          "begin": "/\\*",
+          "end": "\\*/"
+        },
+        {
+          "match": "((//).*)$",
+          "captures": {
+            "1": {
+              "name": "comment.line.double-slash.mint"
+            }
+          }
+        }
+      ]
     },
     "css": {
       "patterns": [
@@ -189,7 +201,10 @@
         "0": {
           "name": "keyword.directive.mint",
           "patterns": [
-            { "match": "(?<=@svg\\()[^\\)]*", "name": "string.unquoted.mint" },
+            {
+              "match": "(?<=@svg\\()[^\\)]*",
+              "name": "string.unquoted.mint"
+            },
             {
               "match": "(?<=@documentation\\()[^\\)]*",
               "name": "entity.name.class.mint"
@@ -483,7 +498,11 @@
             {
               "begin": "\\(",
               "end": "\\)",
-              "patterns": [{ "include": "#keywords" }],
+              "patterns": [
+                {
+                  "include": "#keywords"
+                }
+              ],
               "name": "punctuation.params.style.mint"
             },
             {

--- a/syntaxes/mint.tmLanguage.yaml
+++ b/syntaxes/mint.tmLanguage.yaml
@@ -16,9 +16,14 @@ patterns:
 
 repository:
   comments:
-    name: comment.block.mint
-    begin: "/\\*"
-    end: "\\*/"
+    patterns:
+      - name: comment.block.mint
+        begin: "/\\*"
+        end: "\\*/"
+      - match: "((//).*)$"
+        captures:
+          '1':
+            name: "comment.line.double-slash.mint"
 
   css:
     patterns:


### PR DESCRIPTION
Since mint-lang/mint#451 landed with line comments 🎉 🎉 🎉 🎉 🎉 🎉 this updates the vscode `tmLanguage` to support line comments. Works for both standalone and in-line:

```mint
// Hello! This is a comment. /* asdf */
fun doSomething (number : Number) { // Test comment 2 works
  "hello"
}
```